### PR TITLE
Fix attribute deserialization

### DIFF
--- a/src/DeserializeCollection.cs
+++ b/src/DeserializeCollection.cs
@@ -23,11 +23,6 @@ partial class XmlSerializer
                 _deserializer = deserializer;
             }
 
-            public void Initialize(ISerdeInfo typeInfo)
-            {
-                _index = 0;
-            }
-
             public int? SizeOpt => null;
 
             public int TryReadIndex(ISerdeInfo info)

--- a/src/DeserializeCollection.cs
+++ b/src/DeserializeCollection.cs
@@ -42,6 +42,9 @@ partial class XmlSerializer
                 // Check if we've reached the end of the collection
                 if (reader.NodeType == XmlNodeType.EndElement)
                 {
+                    // Consume our end element before returning - deserializers are responsible
+                    // for fully consuming themselves, leaving cursor after the element.
+                    reader.ReadEndElement();
                     return ITypeDeserializer.EndOfType;
                 }
 
@@ -53,6 +56,24 @@ partial class XmlSerializer
                 throw new DeserializeException($"Unexpected XML node type {reader.NodeType} while reading collection.");
             }
 
+            public T ReadValue<T>(ISerdeInfo info, int index, IDeserialize<T> deserialize)
+                where T : class?
+            {
+                // XML doesn't really have lists, so lists are treated as repeated elements
+                // with the type name as the element name.
+                // The inner deserializer is responsible for fully consuming itself,
+                // including its end element.
+                var result = deserialize.Deserialize(_deserializer);
+                _index++;
+                return result;
+            }
+
+            public void SkipValue(ISerdeInfo info, int index)
+            {
+                _deserializer._reader.Skip();
+                _index++;
+            }
+
             public (int, string?) TryReadIndexWithName(ISerdeInfo info)
             {
                 return (TryReadIndex(info), null);
@@ -60,11 +81,7 @@ partial class XmlSerializer
 
             public void End(ISerdeInfo info)
             {
-                var reader = _deserializer._reader;
-                if (reader.NodeType == XmlNodeType.EndElement)
-                {
-                    reader.ReadEndElement();
-                }
+                // End element already consumed when TryReadIndex returned EndOfType
             }
 
             private string ReadElementContent()
@@ -108,25 +125,6 @@ partial class XmlSerializer
                 var span = writer.GetSpan(bytes.Length);
                 bytes.CopyTo(span);
                 writer.Advance(bytes.Length);
-            }
-
-            public T ReadValue<T>(ISerdeInfo info, int index, IDeserialize<T> deserialize)
-                where T : class?
-            {
-                // XML doesn't really have lists, so lists are treated as repeated elements
-                // with the type name as the element name.
-                var reader = _deserializer._reader;
-                reader.ReadStartElement();
-                var result = deserialize.Deserialize(_deserializer);
-                _deserializer._reader.ReadEndElement();
-                _index++;
-                return result;
-            }
-
-            public void SkipValue(ISerdeInfo info, int index)
-            {
-                _deserializer._reader.Skip();
-                _index++;
             }
         }
     }

--- a/src/DeserializeEnum.cs
+++ b/src/DeserializeEnum.cs
@@ -29,8 +29,12 @@ partial class XmlSerializer
 
             public (int, string?) TryReadIndexWithName(ISerdeInfo info)
             {
-                // Read the enum value as a string. Reader should be advanced to the content.
-                var value = _deserializer._reader.ReadContentAsString();
+                // Read the enum value as a string. Reader should be on the element start.
+                var reader = _deserializer._reader;
+                reader.ReadStartElement();
+                var value = reader.ReadContentAsString();
+                // Consume the end element - deserializers are responsible for fully consuming themselves
+                reader.ReadEndElement();
 
                 // Try to find the index by matching the string value
                 var index = info.TryGetIndex(System.Text.Encoding.UTF8.GetBytes(value));

--- a/src/DeserializeType.cs
+++ b/src/DeserializeType.cs
@@ -1,8 +1,10 @@
 
 using System;
 using System.Buffers;
+using System.Diagnostics;
 using System.Globalization;
 using System.Xml;
+using System.Xml.Serialization;
 
 namespace Serde.Xml;
 
@@ -17,19 +19,30 @@ partial class XmlSerializer
         {
             private readonly Deserializer _deserializer;
             private int _attributeCount;
-            private int _currentAttributeIndex;
-            private bool _inAttributes;
+            private State _state;
 
-            public DeserializeType(Deserializer deserializer)
+            private enum State
             {
-                _deserializer = deserializer;
+                ReadingAttributes,
+                FinishedAttributes,
+                ReadingElements,
             }
 
-            public void Initialize()
+            /// <summary>
+            /// Expects input to be positioned at the start of an element representing the type.
+            /// This allows for reading the attributes or content, or skipping the whole element
+            /// entirely if it's empty.
+            /// </summary>
+            public DeserializeType(Deserializer deserializer)
             {
+                Debug.Assert(deserializer._reader.NodeType == XmlNodeType.Element);
+                _deserializer = deserializer;
                 _attributeCount = _deserializer._reader.AttributeCount;
-                _currentAttributeIndex = 0;
-                _inAttributes = _attributeCount > 0;
+                _state = _attributeCount > 0 ? State.ReadingAttributes : State.FinishedAttributes;
+                if (_state == State.ReadingAttributes)
+                {
+                    _deserializer._reader.MoveToFirstAttribute();
+                }
             }
 
             public int? SizeOpt => null;
@@ -39,22 +52,73 @@ partial class XmlSerializer
                 return TryReadIndexWithName(info).Item1;
             }
 
+            private int TryGetIndexWithAttributes(ISerdeInfo info, string attrName)
+            {
+                // First try to read standard property info
+                var attrNameU8 = System.Text.Encoding.UTF8.GetBytes(attrName);
+                var index = info.TryGetIndex(attrNameU8);
+                if (index != ITypeDeserializer.IndexNotFound)
+                {
+                    return index;
+                }
+
+                // Search the attributes for a match
+                for (int i = 0; i < info.FieldCount; i++)
+                {
+                    var attrs = info.GetFieldAttributes(i);
+                    foreach (var attr in attrs)
+                    {
+                        if ((attr.AttributeType == typeof(XmlAttributeAttribute) || attr.AttributeType == typeof(XmlElementAttribute)) &&
+                            attr.ConstructorArguments is [ { Value: string fieldName } ] &&
+                            fieldName == attrName)
+                        {
+                                return i;
+                        }
+                    }
+                }
+
+                return ITypeDeserializer.IndexNotFound;
+            }
+
             public (int, string?) TryReadIndexWithName(ISerdeInfo info)
             {
                 var reader = _deserializer._reader;
                 int index;
 
                 // First read all attributes
-                if (_inAttributes)
+                if (_state == State.ReadingAttributes)
                 {
                     var attrName = reader.Name;
-                    index = info.TryGetIndex(System.Text.Encoding.UTF8.GetBytes(attrName));
+                    index = TryGetIndexWithAttributes(info, attrName);
                     return (index, index == ITypeDeserializer.IndexNotFound ? attrName : null);
                 }
 
-                // Then read child elements
-                if (reader.NodeType == XmlNodeType.EndElement || reader.EOF)
+                if (reader.EOF)
                 {
+                    throw new DeserializeException("Unexpected end of XML while reading type.");
+                }
+
+                if (_state == State.FinishedAttributes)
+                {
+                    if (reader.IsEmptyElement)
+                    {
+                        // Consume the empty element and signal end of type
+                        reader.Read();
+                        return (ITypeDeserializer.EndOfType, null);
+                    }
+                    _state = State.ReadingElements;
+                    reader.ReadStartElement(); // move to first child element
+                }
+
+                Debug.Assert(_state == State.ReadingElements);
+
+
+                // Then read child elements
+                if (reader.NodeType is XmlNodeType.EndElement)
+                {
+                    // Consume our end element before returning - deserializers are responsible
+                    // for fully consuming themselves, leaving cursor after the element.
+                    reader.ReadEndElement();
                     return (ITypeDeserializer.EndOfType, null);
                 }
 
@@ -64,19 +128,8 @@ partial class XmlSerializer
                 }
 
                 var elementName = reader.Name;
-                reader.ReadStartElement();
-                index = info.TryGetIndex(System.Text.Encoding.UTF8.GetBytes(elementName));
+                index = TryGetIndexWithAttributes(info, elementName);
                 return (index, index == ITypeDeserializer.IndexNotFound ? elementName : null);
-            }
-
-            public void End(ISerdeInfo info)
-            {
-                var reader = _deserializer._reader;
-                // Read the end element if we're at one
-                if (reader.NodeType == XmlNodeType.EndElement)
-                {
-                    reader.ReadEndElement();
-                }
             }
 
             private string ReadContent(ISerdeInfo info, int index)
@@ -88,20 +141,13 @@ partial class XmlSerializer
                     var v = reader.Value;
                     if (!reader.MoveToNextAttribute())
                     {
-                        _inAttributes = false;
-                        _ = reader.Read();
+                        _state = State.FinishedAttributes;
+                        reader.MoveToElement();
                     }
                     return v;
                 }
-                // Otherwise read content
-                var content = reader.ReadContentAsString();
-                // Every field should be followed by an end element with the name of the field
-                var fieldName = info.GetFieldStringName(index);
-                if (reader.NodeType != XmlNodeType.EndElement || reader.Name != fieldName)
-                {
-                    throw new DeserializeException($"Expected end element </{fieldName}> but found {reader.NodeType} with name {reader.Name}.");
-                }
-                reader.ReadEndElement();
+                // Otherwise read content. We should be on an element.
+                var content = reader.ReadElementContentAsString();
                 return content;
             }
 
@@ -144,11 +190,10 @@ partial class XmlSerializer
             public T ReadValue<T>(ISerdeInfo info, int index, IDeserialize<T> deserialize)
                 where T : class?
             {
-                // TryReadIndex should have already advanced to the nested element
-                var result = deserialize.Deserialize(_deserializer);
-                // After the inner deserializer completes, consume the end element for the field
-                _deserializer._reader.ReadEndElement();
-                return result;
+                // TryReadIndex should have already advanced to the nested element.
+                // The inner deserializer is responsible for fully consuming itself,
+                // including its end element.
+                return deserialize.Deserialize(_deserializer);
             }
 
             public void SkipValue(ISerdeInfo info, int index)
@@ -156,20 +201,16 @@ partial class XmlSerializer
                 var reader = _deserializer._reader;
                 if (reader.NodeType == XmlNodeType.Attribute)
                 {
-                    // If we're on an attribute, just skip to the next attribute/element
+                    // If we're on an attribute, just skip to the next attribute
                     if (!reader.MoveToNextAttribute())
                     {
-                        _inAttributes = false;
-                        _ = reader.Read();
+                        _state = State.FinishedAttributes;
+                        reader.MoveToElement();
                     }
                     return;
                 }
 
                 _deserializer._reader.Skip();
-                if (_inAttributes && _currentAttributeIndex == 0)
-                {
-                    _inAttributes = false;
-                }
             }
         }
     }

--- a/src/Deserializer.cs
+++ b/src/Deserializer.cs
@@ -12,7 +12,6 @@ partial class XmlSerializer
     private sealed partial class Deserializer : IDeserializer
     {
         private readonly XmlReader _reader;
-        private readonly DeserializeType _deserializeType;
         private readonly DeserializeCollection _deserializeCollection;
         private readonly DeserializeEnum _deserializeEnum;
 
@@ -33,25 +32,15 @@ partial class XmlSerializer
                 throw new DeserializeException("Expected an element at the start of the XML.");
             }
 
-            if (_reader.HasAttributes)
-            {
-                _reader.MoveToFirstAttribute();
-            }
-            else
-            {
-                _reader.ReadStartElement();
-            }
-
             // Initialize cached deserializers
-            _deserializeType = new DeserializeType(this);
             _deserializeCollection = new DeserializeCollection(this);
             _deserializeEnum = new DeserializeEnum(this);
         }
 
         public void Dispose()
         {
-            // Read the end element of the root
-            _reader.ReadEndElement();
+            // The root deserializer should have consumed its own end element,
+            // so we should be at EOF.
             if (!_reader.EOF)
             {
                 throw new InvalidOperationException("Deserializer disposed before reaching end of XML.");
@@ -156,13 +145,14 @@ partial class XmlSerializer
         {
             if (typeInfo.Kind == InfoKind.List || typeInfo.Kind == InfoKind.Dictionary)
             {
+                // Collections are always nested so we want to read the start element here
+                _reader.ReadStartElement();
                 _deserializeCollection.Initialize(typeInfo);
                 return _deserializeCollection;
             }
             else if (typeInfo.Kind == InfoKind.CustomType || typeInfo.Kind == InfoKind.Nullable)
             {
-                _deserializeType.Initialize();
-                return _deserializeType;
+                return new DeserializeType(this);
             }
             else if (typeInfo.Kind == InfoKind.Enum)
             {

--- a/src/Deserializer.cs
+++ b/src/Deserializer.cs
@@ -12,7 +12,6 @@ partial class XmlSerializer
     private sealed partial class Deserializer : IDeserializer
     {
         private readonly XmlReader _reader;
-        private readonly DeserializeCollection _deserializeCollection;
         private readonly DeserializeEnum _deserializeEnum;
 
         public Deserializer(string xml)
@@ -33,7 +32,6 @@ partial class XmlSerializer
             }
 
             // Initialize cached deserializers
-            _deserializeCollection = new DeserializeCollection(this);
             _deserializeEnum = new DeserializeEnum(this);
         }
 
@@ -147,8 +145,7 @@ partial class XmlSerializer
             {
                 // Collections are always nested so we want to read the start element here
                 _reader.ReadStartElement();
-                _deserializeCollection.Initialize(typeInfo);
-                return _deserializeCollection;
+                return new DeserializeCollection(this);
             }
             else if (typeInfo.Kind == InfoKind.CustomType || typeInfo.Kind == InfoKind.Nullable)
             {

--- a/tests/XmlTests.cs
+++ b/tests/XmlTests.cs
@@ -410,6 +410,48 @@ public partial class XmlTests
         Assert.True(deserialized.BoolField);
     }
 
+    [GenerateSerialize]
+    [GenerateDeserialize]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+    public partial class ListItemWithAttribute
+    {
+        [System.Xml.Serialization.XmlAttribute]
+        [SerdeMemberOptions(ProvideAttributes = true)]
+        public required string Name { get; set; }
+    }
+
+    [GenerateSerialize]
+    [GenerateDeserialize]
+    [SerdeTypeOptions(MemberFormat = MemberFormat.None)]
+    public partial class ParentWithAttributeOnlyList
+    {
+        public ListItemWithAttribute[] Items { get; set; } = [];
+    }
+
+    /// <summary>
+    /// Test deserializing a list where each element only has attributes (no child elements).
+    /// This is a common XML pattern with self-closing elements.
+    /// </summary>
+    [Fact]
+    public void ListWithAttributeOnlyElementsTest()
+    {
+        const string xml = """
+<?xml version="1.0" encoding="utf-16"?>
+<ParentWithAttributeOnlyList>
+  <Items>
+    <ListItemWithAttribute Name="elem1" />
+    <ListItemWithAttribute Name="elem2" />
+    <ListItemWithAttribute Name="elem3" />
+  </Items>
+</ParentWithAttributeOnlyList>
+""";
+        var deserialized = XmlSerializer.Deserialize<ParentWithAttributeOnlyList>(xml);
+        Assert.Equal(3, deserialized.Items.Length);
+        Assert.Equal("elem1", deserialized.Items[0].Name);
+        Assert.Equal("elem2", deserialized.Items[1].Name);
+        Assert.Equal("elem3", deserialized.Items[2].Name);
+    }
+
     /// <summary>
     /// Test that when deserialization throws an exception, we get the original exception
     /// rather than an exception from Dispose (e.g., "Deserializer disposed before reaching end of XML").

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.IDeserialize.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.IDeserialize.g.cs
@@ -1,0 +1,59 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ListItemWithAttribute
+    {
+        sealed partial class _DeObj : Serde.IDeserialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Xml.Test.XmlTests.ListItemWithAttribute.s_serdeInfo;
+
+            Serde.Xml.Test.XmlTests.ListItemWithAttribute Serde.IDeserialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute>.Deserialize(IDeserializer deserializer)
+            {
+                string _l_name = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_name = typeDeserialize.ReadString(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Xml.Test.XmlTests.ListItemWithAttribute() {
+                    Name = _l_name,
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.IDeserializeProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.IDeserializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ListItemWithAttribute : Serde.IDeserializeProvider<Serde.Xml.Test.XmlTests.ListItemWithAttribute>
+    {
+        static global::Serde.IDeserialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute> global::Serde.IDeserializeProvider<Serde.Xml.Test.XmlTests.ListItemWithAttribute>.Instance { get; }
+            = new Serde.Xml.Test.XmlTests.ListItemWithAttribute._DeObj();
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerdeInfoProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerdeInfoProvider.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ListItemWithAttribute
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "ListItemWithAttribute",
+        typeof(Serde.Xml.Test.XmlTests.ListItemWithAttribute).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("Name", global::Serde.SerdeInfoProvider.GetSerializeInfo<string, global::Serde.StringProxy>(), typeof(Serde.Xml.Test.XmlTests.ListItemWithAttribute).GetProperty("Name"))
+        }
+        );
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerialize.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerialize.g.cs
@@ -1,0 +1,27 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ListItemWithAttribute
+    {
+        sealed partial class _SerObj : Serde.ISerialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Xml.Test.XmlTests.ListItemWithAttribute.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute>.Serialize(Serde.Xml.Test.XmlTests.ListItemWithAttribute value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteString(_l_info, 0, value.Name);
+                _l_type.End(_l_info);
+            }
+
+        }
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerializeProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ListItemWithAttribute.ISerializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ListItemWithAttribute : Serde.ISerializeProvider<Serde.Xml.Test.XmlTests.ListItemWithAttribute>
+    {
+        static global::Serde.ISerialize<Serde.Xml.Test.XmlTests.ListItemWithAttribute> global::Serde.ISerializeProvider<Serde.Xml.Test.XmlTests.ListItemWithAttribute>.Instance { get; }
+            = new Serde.Xml.Test.XmlTests.ListItemWithAttribute._SerObj();
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.IDeserialize.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.IDeserialize.g.cs
@@ -1,0 +1,59 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ParentWithAttributeOnlyList
+    {
+        sealed partial class _DeObj : Serde.IDeserialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.s_serdeInfo;
+
+            Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList Serde.IDeserialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>.Deserialize(IDeserializer deserializer)
+            {
+                Serde.Xml.Test.XmlTests.ListItemWithAttribute[] _l_items = default!;
+
+                byte _r_assignedValid = 0;
+
+                var _l_serdeInfo = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var typeDeserialize = deserializer.ReadType(_l_serdeInfo);
+                while (true)
+                {
+                    var (_l_index_, _) = typeDeserialize.TryReadIndexWithName(_l_serdeInfo);
+                    if (_l_index_ == Serde.ITypeDeserializer.EndOfType)
+                    {
+                        break;
+                    }
+
+                    switch (_l_index_)
+                    {
+                        case 0:
+                            Serde.DeserializeException.ThrowIfDuplicate(_r_assignedValid, 0, _l_serdeInfo);
+                            _l_items = typeDeserialize.ReadValue<Serde.Xml.Test.XmlTests.ListItemWithAttribute[], Serde.ArrayProxy.De<Serde.Xml.Test.XmlTests.ListItemWithAttribute, Serde.Xml.Test.XmlTests.ListItemWithAttribute>>(_l_serdeInfo, _l_index_);
+                            _r_assignedValid |= ((byte)1) << 0;
+                            break;
+                        case Serde.ITypeDeserializer.IndexNotFound:
+                            typeDeserialize.SkipValue(_l_serdeInfo, _l_index_);
+                            break;
+                        default:
+                            throw new InvalidOperationException("Unexpected index: " + _l_index_);
+                    }
+                }
+                if ((_r_assignedValid & 0b1) != 0b1)
+                {
+                    throw Serde.DeserializeException.UnassignedMember();
+                }
+                var newType = new Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList() {
+                    Items = _l_items,
+                };
+
+                return newType;
+            }
+        }
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.IDeserializeProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.IDeserializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ParentWithAttributeOnlyList : Serde.IDeserializeProvider<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>
+    {
+        static global::Serde.IDeserialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList> global::Serde.IDeserializeProvider<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>.Instance { get; }
+            = new Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList._DeObj();
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerdeInfoProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerdeInfoProvider.g.cs
@@ -1,0 +1,18 @@
+
+#nullable enable
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ParentWithAttributeOnlyList
+    {
+        private static global::Serde.ISerdeInfo s_serdeInfo = Serde.SerdeInfo.MakeCustom(
+            "ParentWithAttributeOnlyList",
+        typeof(Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList).GetCustomAttributesData(),
+        new (string, global::Serde.ISerdeInfo, System.Reflection.MemberInfo?)[] {
+            ("Items", global::Serde.SerdeInfoProvider.GetSerializeInfo<Serde.Xml.Test.XmlTests.ListItemWithAttribute[], Serde.ArrayProxy.Ser<Serde.Xml.Test.XmlTests.ListItemWithAttribute, Serde.Xml.Test.XmlTests.ListItemWithAttribute>>(), typeof(Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList).GetProperty("Items"))
+        }
+        );
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerialize.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerialize.g.cs
@@ -1,0 +1,27 @@
+
+#nullable enable
+
+using System;
+using Serde;
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ParentWithAttributeOnlyList
+    {
+        sealed partial class _SerObj : Serde.ISerialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>
+        {
+            global::Serde.ISerdeInfo global::Serde.ISerdeInfoProvider.SerdeInfo => Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.s_serdeInfo;
+
+            void global::Serde.ISerialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>.Serialize(Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList value, global::Serde.ISerializer serializer)
+            {
+                var _l_info = global::Serde.SerdeInfoProvider.GetInfo(this);
+                var _l_type = serializer.WriteType(_l_info);
+                _l_type.WriteValue<Serde.Xml.Test.XmlTests.ListItemWithAttribute[], Serde.ArrayProxy.Ser<Serde.Xml.Test.XmlTests.ListItemWithAttribute, Serde.Xml.Test.XmlTests.ListItemWithAttribute>>(_l_info, 0, value.Items);
+                _l_type.End(_l_info);
+            }
+
+        }
+    }
+}

--- a/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerializeProvider.g.cs
+++ b/tests/generated/SerdeGenerator/Serde.SerdeImplRoslynGenerator/Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList.ISerializeProvider.g.cs
@@ -1,0 +1,11 @@
+
+namespace Serde.Xml.Test;
+
+partial class XmlTests
+{
+    partial class ParentWithAttributeOnlyList : Serde.ISerializeProvider<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>
+    {
+        static global::Serde.ISerialize<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList> global::Serde.ISerializeProvider<Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList>.Instance { get; }
+            = new Serde.Xml.Test.XmlTests.ParentWithAttributeOnlyList._SerObj();
+    }
+}


### PR DESCRIPTION
This pull request refactors the XML deserialization logic to improve correctness and robustness, especially around handling attributes, self-closing elements, and end-element consumption. The changes also add test coverage for a common XML pattern involving lists of elements with only attributes.

**Deserializer logic improvements**

* Refactored `DeserializeType` to use an explicit state machine for attribute and element reading, improving clarity and correctness when handling attributes and self-closing elements. The attribute lookup now supports both standard property info and XML attribute/element annotations.
* Changed deserializer methods so that inner deserializers are responsible for fully consuming their own end elements, ensuring the XML reader's cursor is correctly positioned after each deserialization. This affects both type and collection deserialization.

**Attribute and element handling**

* Improved attribute matching logic to support both XML attribute and element annotations, enabling correct mapping of XML attributes to object fields even when using custom naming.
* Fixed enum deserialization to correctly consume start and end elements, ensuring the reader is properly advanced and attributes are fully consumed.

**Test coverage**

* Added a new test for deserializing lists of elements that only have attributes (no child elements), verifying support for self-closing elements and attribute-only list patterns. 